### PR TITLE
Fix missing space after flag in the Tree command.

### DIFF
--- a/custom_aliases
+++ b/custom_aliases
@@ -18,7 +18,7 @@ alias up-up="sudo apt-get update && sudo apt-get upgrade -y"
 alias py="python3"
 
 # Multiple commands
-alias treels="ls -la | tree -d -L1"
+alias treels="ls -la | tree -d -L 1"
 alias pc="ps auxf"
 
 # Functions


### PR DESCRIPTION
Won't work without a space on most of the shells.
If you attach an argument to a flag, it will search for a `-L1` flag which doesn't exist.